### PR TITLE
fix jitpack badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Get it
 ======
 
 KEthereum is available via jitpack:
-[![](https://jitpack.io/v/walleth/kethereum.svg)](https://jitpack.io/#walleth/kethereum)
+[![](https://jitpack.io/v/komputing/KEthereum.svg)](https://jitpack.io/#komputing/KEthereum)
 
 License
 =======


### PR DESCRIPTION
A tiny PR with a URL fix for the jitpack badge