### PR TITLE
replace khex and khash dependencies with the komputing variants

### DIFF
--- a/base58/build.gradle
+++ b/base58/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
     implementation project(path: ':hashes')
-    testImplementation "com.github.walleth:khex:$khex_version"
+    testImplementation "com.github.komputing:KHex:$khex_version"
 
 }

--- a/bip32/build.gradle
+++ b/bip32/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     implementation project(path: ':extensions')
     implementation project(path: ':model')
 
-    testImplementation "com.github.walleth:khex:$khex_version"
+    testImplementation "com.github.komputing:KHex:$khex_version"
     testImplementation project(path: ':crypto_impl_bouncycastle')
 
     testImplementation project(":test_data")

--- a/bip39/build.gradle
+++ b/bip39/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     implementation project(path: ':crypto')
     implementation project(path: ':crypto_api')
 
-    implementation "com.github.walleth:khex:$khex_version"
+    implementation "com.github.komputing:KHex:$khex_version"
 
     testImplementation project(path: ':bip39_wordlist_en')
     testImplementation project(path: ':crypto_impl_spongycastle')

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
 
         slf4jVersion = '1.7.25'
         khex_version = '0.6'
+        khash_version = '0.8'
 
         klaxon_version = '5.0.5'
         moshi_version = '1.8.0'

--- a/contract_abi_types/build.gradle
+++ b/contract_abi_types/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
     implementation project(":extensions")
 
-    implementation "com.github.walleth:khex:$khex_version"
+    implementation "com.github.komputing:KHex:$khex_version"
 }

--- a/crypto/build.gradle
+++ b/crypto/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     implementation project(":extensions")
     implementation project(":crypto_api")
     
-    implementation "com.github.walleth:khex:$khex_version"
+    implementation "com.github.komputing:KHex:$khex_version"
 
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
 

--- a/eip155/build.gradle
+++ b/eip155/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     implementation project(":functions")
     implementation project(":rlp")
 
-    testImplementation "com.github.walleth:khex:$khex_version"
+    testImplementation "com.github.komputing:KHex:$khex_version"
     testImplementation project(":crypto_impl_spongycastle")
     testImplementation "com.beust:klaxon:$klaxon_version"
 }

--- a/eip191/build.gradle
+++ b/eip191/build.gradle
@@ -5,6 +5,6 @@ dependencies {
     implementation project(":functions")
     implementation project(":rlp")
 
-    testImplementation "com.github.walleth:khex:$khex_version"
+    testImplementation "com.github.komputing:KHex:$khex_version"
     testImplementation project(":crypto_impl_spongycastle")
 }

--- a/erc55/build.gradle
+++ b/erc55/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     implementation project(":model")
     implementation project(":functions")
     implementation project(":keccak_shortcut")
-    implementation "com.github.walleth:khex:$khex_version"
+    implementation "com.github.komputing:KHex:$khex_version"
 
     testImplementation project(":crypto_impl_spongycastle")
 }

--- a/extensions/build.gradle
+++ b/extensions/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
 
-    implementation "com.github.walleth:khex:$khex_version"
+    implementation "com.github.komputing:KHex:$khex_version"
 
 }

--- a/functions/build.gradle
+++ b/functions/build.gradle
@@ -3,7 +3,7 @@ dependencies {
     implementation project(':rlp')
     implementation project(":keccak_shortcut")
 
-    implementation "com.github.walleth:khex:$khex_version"
+    implementation "com.github.komputing:KHex:$khex_version"
 
     testImplementation "com.beust:klaxon:$klaxon_version"
 }

--- a/hashes/build.gradle
+++ b/hashes/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-    implementation "com.github.walleth:khex:$khex_version"
+    implementation "com.github.komputing:KHex:$khex_version"
     compile project(path: ':ripemd160')
 }

--- a/keccak_shortcut/build.gradle
+++ b/keccak_shortcut/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-    implementation "com.github.walleth:sha3:0.8"
-    implementation "com.github.walleth:khex:$khex_version"
+    implementation "com.github.komputing:KHex:$khex_version"
+    implementation "com.github.komputing:KHash:$khash_version"
 }

--- a/method_signatures/build.gradle
+++ b/method_signatures/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     implementation project(':keccak_shortcut')
-    implementation "com.github.walleth:khex:$khex_version"
+    implementation "com.github.komputing:KHex:$khex_version"
 
     testImplementation project(":crypto_impl_spongycastle")
 }

--- a/model/build.gradle
+++ b/model/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
-    implementation "com.github.walleth:khex:$khex_version"
+    implementation "com.github.komputing:KHex:$khex_version"
     implementation project(":extensions")
 }

--- a/ripemd160/build.gradle
+++ b/ripemd160/build.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    testImplementation "com.github.walleth:khex:$khex_version"
+    testImplementation "com.github.komputing:KHex:$khex_version"
 }

--- a/rlp/build.gradle
+++ b/rlp/build.gradle
@@ -2,5 +2,5 @@ dependencies {
     implementation project(":extensions")
 
     testImplementation project(":functions")
-    testImplementation "com.github.walleth:khex:$khex_version"
+    testImplementation "com.github.komputing:KHex:$khex_version"
 }

--- a/rpc/build.gradle
+++ b/rpc/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:${okhttp_version}"
     implementation "com.squareup.moshi:moshi:${moshi_version}"
 
-    implementation "com.github.walleth:khex:$khex_version"
+    implementation "com.github.komputing:KHex:$khex_version"
 
     testImplementation "com.squareup.okhttp3:mockwebserver:${okhttp_version}"
     testImplementation 'org.threeten:threetenbp:1.3.8'

--- a/test_data/build.gradle
+++ b/test_data/build.gradle
@@ -1,4 +1,4 @@
 dependencies {
     implementation project(":model")
-    implementation "com.github.walleth:khex:$khex_version"
+    implementation "com.github.komputing:KHex:$khex_version"
 }

--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation project(":extensions")
     implementation project(":model")
 
-    implementation "com.github.walleth:khex:$khex_version"
+    implementation "com.github.komputing:KHex:$khex_version"
 
     implementation "com.squareup.moshi:moshi:$moshi_version"
     implementation "com.squareup.moshi:moshi-adapters:$moshi_version"


### PR DESCRIPTION
fixes #65

I used KHash 0.8 since the 1.0.0-RC releases seem to still have issues.

KHex seems to be linked much more often and also has to point to the new groupID so I changed that as well.