### PR TITLE
use lowercase name in jitpack badge to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Get it
 ======
 
 KEthereum is available via jitpack:
-[![](https://jitpack.io/v/komputing/KEthereum.svg)](https://jitpack.io/#komputing/KEthereum)
+[![](https://jitpack.io/v/komputing/kethereum.svg)](https://jitpack.io/#komputing/kethereum)
 
 License
 =======


### PR DESCRIPTION
This relates to #73 
The jitpack badge also needs an update to avoid confusion and potential duplicate class errors.