### PR TITLE
replace java's 'System::arraycopy' with Kotlin's 'copyInto'

### DIFF
--- a/bip39/src/main/kotlin/org/kethereum/bip39/Mnemonic.kt
+++ b/bip39/src/main/kotlin/org/kethereum/bip39/Mnemonic.kt
@@ -94,9 +94,8 @@ fun entropyToMnemonic(entropy: ByteArray, wordList: List<String>): String {
     val checksumLengthBits = entropyBits.size / 32
 
     val concatBits = BooleanArray(entropyBits.size + checksumLengthBits)
-    System.arraycopy(entropyBits, 0, concatBits, 0, entropyBits.size)
-    System.arraycopy(hashBits, 0, concatBits, entropyBits.size, checksumLengthBits)
-
+    entropyBits.copyInto(concatBits)
+    hashBits.copyInto(concatBits, destinationOffset = entropyBits.size, endIndex = checksumLengthBits)
 
     val words = ArrayList<String>().toMutableList()
     val numWords = concatBits.size / 11

--- a/extensions_kotlin/src/main/kotlin/org/kethereum/extensions/BigInteger.kt
+++ b/extensions_kotlin/src/main/kotlin/org/kethereum/extensions/BigInteger.kt
@@ -16,8 +16,7 @@ fun BigInteger.toBytesPadded(length: Int): ByteArray {
     }
 
     val destOffset = length - bytes.size + offset
-    System.arraycopy(bytes, offset, result, destOffset, bytes.size - offset)
-    return result
+    return bytes.copyInto(result, destinationOffset = destOffset, startIndex = offset)
 }
 
 fun BigInteger.toHexStringNoPrefix(): String = toString(16)

--- a/wallet/src/main/kotlin/org/kethereum/wallet/Wallet.kt
+++ b/wallet/src/main/kotlin/org/kethereum/wallet/Wallet.kt
@@ -101,8 +101,8 @@ private fun performCipherOperation(operation: AESCipher.Operation, iv: ByteArray
 private fun generateMac(derivedKey: ByteArray, cipherText: ByteArray): ByteArray {
     val result = ByteArray(16 + cipherText.size)
 
-    System.arraycopy(derivedKey, 16, result, 0, 16)
-    System.arraycopy(cipherText, 0, result, 16, cipherText.size)
+    derivedKey.copyInto(result, startIndex = 16)
+    cipherText.copyInto(result, destinationOffset = 16)
 
     return result.keccak()
 }


### PR DESCRIPTION
Eliminate usages of java's `System::arraycopy` by preferring Kotlin's 'copyInto', 'copyOf' or 'copyRanges' which are more readable and support multiplatform 