### PR TITLE
EIP191 signature to PublicKey conversion

### DIFF
--- a/crypto/src/main/kotlin/org/kethereum/crypto/Signatures.kt
+++ b/crypto/src/main/kotlin/org/kethereum/crypto/Signatures.kt
@@ -1,9 +1,18 @@
 package org.kethereum.crypto
 
+import org.kethereum.extensions.hexToBigInteger
 import org.kethereum.extensions.toHexStringNoPrefix
 import org.kethereum.extensions.toHexStringZeroPadded
 import org.kethereum.model.SignatureData
+import org.komputing.khex.model.HexString
 import java.math.BigInteger
+
+fun HexString.toSignatureData(): SignatureData {
+    val r = HexString(string.substring(0, 64)).hexToBigInteger()
+    val s = HexString(string.substring(64, 128)).hexToBigInteger()
+    val v = HexString(string.substring(128)).hexToBigInteger()
+    return SignatureData(r, s, v)
+}
 
 fun SignatureData.toHex() = r.to64BytePaddedHex() + s.to64BytePaddedHex() + v.toHexStringNoPrefix()
 

--- a/crypto/src/main/kotlin/org/kethereum/crypto/Signatures.kt
+++ b/crypto/src/main/kotlin/org/kethereum/crypto/Signatures.kt
@@ -1,18 +1,9 @@
 package org.kethereum.crypto
 
-import org.kethereum.extensions.hexToBigInteger
 import org.kethereum.extensions.toHexStringNoPrefix
 import org.kethereum.extensions.toHexStringZeroPadded
 import org.kethereum.model.SignatureData
-import org.komputing.khex.model.HexString
 import java.math.BigInteger
-
-fun HexString.toSignatureData(): SignatureData {
-    val r = HexString(string.substring(0, 64)).hexToBigInteger()
-    val s = HexString(string.substring(64, 128)).hexToBigInteger()
-    val v = HexString(string.substring(128)).hexToBigInteger()
-    return SignatureData(r, s, v)
-}
 
 fun SignatureData.toHex() = r.to64BytePaddedHex() + s.to64BytePaddedHex() + v.toHexStringNoPrefix()
 

--- a/crypto/src/test/kotlin/org/kethereum/crypto/TheSignatures.kt
+++ b/crypto/src/test/kotlin/org/kethereum/crypto/TheSignatures.kt
@@ -6,19 +6,29 @@ import org.kethereum.extensions.hexToBigInteger
 import org.kethereum.model.SignatureData
 import org.komputing.khex.model.HexString
 
+private const val R = "0x0031f6d21dec448a213585a4a41a28ef3d4337548aa34734478b563036163786"
+private const val S = "0x2ff816ee6bbb82719e983ecd8a33a4b45d32a4b58377ef1381163d75eedc900b"
+private const val V = "0x1b"
+private const val SIGNATURE =
+    "0031f6d21dec448a213585a4a41a28ef3d4337548aa34734478b5630361637862ff816ee6bbb82719e983ecd8a33a4b45d32a4b58377ef1381163d75eedc900b1b"
+
+private val signatureData = SignatureData(
+    HexString(R).hexToBigInteger(),
+    HexString(S).hexToBigInteger(),
+    HexString(V).hexToBigInteger()
+)
+
 class TheSignatures {
 
     @Test
     fun createsCorrectSignatureHex() {
-
-        val signatureData = SignatureData(
-                HexString("0x0031f6d21dec448a213585a4a41a28ef3d4337548aa34734478b563036163786").hexToBigInteger(),
-                HexString("0x2ff816ee6bbb82719e983ecd8a33a4b45d32a4b58377ef1381163d75eedc900b").hexToBigInteger(),
-                27.toBigInteger()
-        )
-
-        assertThat(signatureData.toHex()).isEqualTo("0031f6d21dec448a213585a4a41a28ef3d4337548aa34734478b5630361637862ff816ee6bbb82719e983ecd8a33a4b45d32a4b58377ef1381163d75eedc900b1b")
+        assertThat(signatureData.toHex()).isEqualTo(SIGNATURE)
     }
 
+    @Test
+    fun parsesHexToCorrectSignature() {
+        val signature = HexString(SIGNATURE)
 
+        assertThat(signature.toSignatureData()).isEqualTo(signatureData)
+    }
 }

--- a/crypto/src/test/kotlin/org/kethereum/crypto/TheSignatures.kt
+++ b/crypto/src/test/kotlin/org/kethereum/crypto/TheSignatures.kt
@@ -27,8 +27,11 @@ class TheSignatures {
 
     @Test
     fun parsesHexToCorrectSignature() {
-        val signature = HexString(SIGNATURE)
+        assertThat(SignatureData.fromHex(SIGNATURE)).isEqualTo(signatureData)
+    }
 
-        assertThat(signature.toSignatureData()).isEqualTo(signatureData)
+    @Test
+    fun parsesHexWithPrefixToCorrectSignature() {
+        assertThat(SignatureData.fromHex("0x$SIGNATURE")).isEqualTo(signatureData)
     }
 }

--- a/crypto/src/test/kotlin/org/kethereum/crypto/TheSignatures.kt
+++ b/crypto/src/test/kotlin/org/kethereum/crypto/TheSignatures.kt
@@ -1,10 +1,12 @@
 package org.kethereum.crypto
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.kethereum.extensions.hexToBigInteger
 import org.kethereum.model.SignatureData
 import org.komputing.khex.model.HexString
+import java.security.SignatureException
 
 private const val R = "0x0031f6d21dec448a213585a4a41a28ef3d4337548aa34734478b563036163786"
 private const val S = "0x2ff816ee6bbb82719e983ecd8a33a4b45d32a4b58377ef1381163d75eedc900b"
@@ -33,5 +35,19 @@ class TheSignatures {
     @Test
     fun parsesHexWithPrefixToCorrectSignature() {
         assertThat(SignatureData.fromHex("0x$SIGNATURE")).isEqualTo(signatureData)
+    }
+
+    @Test
+    fun throwsForInvalidHex() {
+        assertThatThrownBy { SignatureData.fromHex("${SIGNATURE}w") }
+            .isInstanceOf(SignatureException::class.java)
+            .hasMessageContaining("Invalid hex string")
+    }
+
+    @Test
+    fun throwsForShorterSignature() {
+        assertThatThrownBy { SignatureData.fromHex(SIGNATURE.substring(5)) }
+            .isInstanceOf(SignatureException::class.java)
+            .hasMessageContaining("Signature hex too short")
     }
 }

--- a/eip191/build.gradle.kts
+++ b/eip191/build.gradle.kts
@@ -5,6 +5,8 @@ dependencies {
     "implementation"(project(":extensions_kotlin"))
     "implementation"(project(":rlp"))
 
+    "implementation"("com.github.komputing:khex:${Versions.khex}")
+
     "testImplementation"("com.github.komputing:khex:${Versions.khex}")
     "testImplementation"(project(":crypto_impl_spongycastle"))
 }

--- a/eip191/build.gradle.kts
+++ b/eip191/build.gradle.kts
@@ -5,7 +5,5 @@ dependencies {
     "implementation"(project(":extensions_kotlin"))
     "implementation"(project(":rlp"))
 
-    "implementation"("com.github.komputing:khex:${Versions.khex}")
-
     "testImplementation"(project(":crypto_impl_spongycastle"))
 }

--- a/eip191/build.gradle.kts
+++ b/eip191/build.gradle.kts
@@ -7,6 +7,5 @@ dependencies {
 
     "implementation"("com.github.komputing:khex:${Versions.khex}")
 
-    "testImplementation"("com.github.komputing:khex:${Versions.khex}")
     "testImplementation"(project(":crypto_impl_spongycastle"))
 }

--- a/eip191/src/main/kotlin/org/kethereum/eip191/EIP191.kt
+++ b/eip191/src/main/kotlin/org/kethereum/eip191/EIP191.kt
@@ -1,7 +1,12 @@
 package org.kethereum.eip191
 
-import org.kethereum.model.ECKeyPair
 import org.kethereum.crypto.signMessage
+import org.kethereum.crypto.signedMessageToKey
+import org.kethereum.crypto.toSignatureData
+import org.kethereum.model.ECKeyPair
+import org.kethereum.model.PublicKey
+import org.kethereum.model.SignatureData
+import org.komputing.khex.model.HexString
 
 /*
 *
@@ -9,11 +14,32 @@ import org.kethereum.crypto.signMessage
 *
 */
 
+private const val MESSAGE_PREFIX: Byte = 0x19
+private const val PERSONAL_SIGN_VERSION: Byte = 0x45
 
 fun ECKeyPair.signWithEIP191(version: Byte, versionSpecificData: ByteArray, message: ByteArray) =
-        signMessage(0x19.toByte().toByteArray() + version.toByteArray() + versionSpecificData + message)
+    signMessage(fullMessage(version, versionSpecificData, message))
 
 fun ECKeyPair.signWithEIP191PersonalSign(message: ByteArray) =
-        signWithEIP191(0x45, ("thereum Signed Message:\n" + message.size).toByteArray(), message)
+    signWithEIP191(PERSONAL_SIGN_VERSION, personalSignVersionData(message), message)
+
+fun personallySignedMessageToKey(message: ByteArray, signature: String): PublicKey =
+    personallySignedMessageToKey(message, HexString(signature).toSignatureData())
+
+fun personallySignedMessageToKey(message: ByteArray, signature: SignatureData): PublicKey =
+    signedMessageToKey(
+        fullMessage(PERSONAL_SIGN_VERSION, personalSignVersionData(message), message),
+        signature
+    )
+
+private fun personalSignVersionData(message: ByteArray): ByteArray =
+    ("thereum Signed Message:\n" + message.size).toByteArray()
+
+private fun fullMessage(
+    version: Byte,
+    versionSpecificData: ByteArray,
+    message: ByteArray,
+): ByteArray =
+    MESSAGE_PREFIX.toByteArray() + version.toByteArray() + versionSpecificData + message
 
 private fun Byte.toByteArray() = ByteArray(1) { this }

--- a/eip191/src/main/kotlin/org/kethereum/eip191/EIP191.kt
+++ b/eip191/src/main/kotlin/org/kethereum/eip191/EIP191.kt
@@ -5,6 +5,7 @@ import org.kethereum.crypto.signedMessageToKey
 import org.kethereum.model.ECKeyPair
 import org.kethereum.model.PublicKey
 import org.kethereum.model.SignatureData
+import java.security.SignatureException
 
 /*
 *
@@ -21,6 +22,18 @@ fun ECKeyPair.signWithEIP191(version: Byte, versionSpecificData: ByteArray, mess
 fun ECKeyPair.signWithEIP191PersonalSign(message: ByteArray) =
     signWithEIP191(PERSONAL_SIGN_VERSION, personalSignVersionData(message), message)
 
+/**
+ * Given an arbitrary piece of text and an Ethereum message signature encoded in bytes,
+ * returns the public key that was used to sign it. This can then be compared to the expected
+ * public key to determine if the signature was correct.
+ *
+ * @param message RLP encoded message.
+ * @param signature The message signature components
+ * @return the public key used to sign the message
+ * @throws SignatureException If the public key could not be recovered or if there was a
+ * signature format error.
+ */
+@Throws(SignatureException::class)
 fun personalSignedMessageToPublicKey(message: ByteArray, signature: SignatureData): PublicKey =
     signedMessageToKey(
         fullMessage(PERSONAL_SIGN_VERSION, personalSignVersionData(message), message),

--- a/eip191/src/main/kotlin/org/kethereum/eip191/EIP191.kt
+++ b/eip191/src/main/kotlin/org/kethereum/eip191/EIP191.kt
@@ -2,11 +2,9 @@ package org.kethereum.eip191
 
 import org.kethereum.crypto.signMessage
 import org.kethereum.crypto.signedMessageToKey
-import org.kethereum.crypto.toSignatureData
 import org.kethereum.model.ECKeyPair
 import org.kethereum.model.PublicKey
 import org.kethereum.model.SignatureData
-import org.komputing.khex.model.HexString
 
 /*
 *
@@ -23,10 +21,7 @@ fun ECKeyPair.signWithEIP191(version: Byte, versionSpecificData: ByteArray, mess
 fun ECKeyPair.signWithEIP191PersonalSign(message: ByteArray) =
     signWithEIP191(PERSONAL_SIGN_VERSION, personalSignVersionData(message), message)
 
-fun personallySignedMessageToKey(message: ByteArray, signature: String): PublicKey =
-    personallySignedMessageToKey(message, HexString(signature).toSignatureData())
-
-fun personallySignedMessageToKey(message: ByteArray, signature: SignatureData): PublicKey =
+fun personalSignedMessageToPublicKey(message: ByteArray, signature: SignatureData): PublicKey =
     signedMessageToKey(
         fullMessage(PERSONAL_SIGN_VERSION, personalSignVersionData(message), message),
         signature

--- a/eip191/src/test/kotlin/org/kethereum/eip191/TheEIP191.kt
+++ b/eip191/src/test/kotlin/org/kethereum/eip191/TheEIP191.kt
@@ -4,19 +4,47 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.kethereum.crypto.createEthereumKeyPair
 import org.kethereum.crypto.signMessage
-
-val KEY_PAIR = createEthereumKeyPair()
+import org.kethereum.crypto.toHex
+import org.kethereum.model.ECKeyPair
+import org.kethereum.model.SignatureData
+import java.util.UUID
 
 class TheSignatures {
 
     @Test
     fun createsCorrectPersonalSignSignature() {
-
+        val keyPair = createEthereumKeyPair()
         val payload = "Test Payload".toByteArray()
 
-        assertThat(KEY_PAIR.signWithEIP191PersonalSign(payload))
-                .isEqualTo(KEY_PAIR.signMessage(("\u0019Ethereum Signed Message:\n" + payload.size).toByteArray() + payload))
+        assertThat(keyPair.signWithEIP191PersonalSign(payload))
+            .isEqualTo(keyPair.personallySign(payload))
     }
 
+    @Test
+    fun retrievesCorrectPublicKeyFromPersonalSignature() {
+        val keyPair = createEthereumKeyPair()
+        val message = UUID.randomUUID().toString().toByteArray()
+        val signature = keyPair.personallySign(message)
+
+        val actualKey = personallySignedMessageToKey(message, signature)
+
+        assertThat(actualKey).isEqualTo(keyPair.publicKey)
+    }
+
+    @Test
+    fun retrievesCorrectPublicKeyFromPersonalHexSignature() {
+        val keyPair = createEthereumKeyPair()
+        val message = UUID.randomUUID().toString().toByteArray()
+        val signature = keyPair.personallySign(message).toHex()
+
+        val actualKey = personallySignedMessageToKey(message, signature)
+
+        assertThat(actualKey).isEqualTo(keyPair.publicKey)
+    }
+
+    private fun ECKeyPair.personallySign(message: ByteArray): SignatureData =
+        signMessage(
+            "\u0019Ethereum Signed Message:\n${message.size}".toByteArray() + message
+        )
 
 }

--- a/eip191/src/test/kotlin/org/kethereum/eip191/TheEIP191.kt
+++ b/eip191/src/test/kotlin/org/kethereum/eip191/TheEIP191.kt
@@ -4,7 +4,6 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.kethereum.crypto.createEthereumKeyPair
 import org.kethereum.crypto.signMessage
-import org.kethereum.crypto.toHex
 import org.kethereum.model.ECKeyPair
 import org.kethereum.model.SignatureData
 import java.util.UUID
@@ -26,18 +25,7 @@ class TheSignatures {
         val message = UUID.randomUUID().toString().toByteArray()
         val signature = keyPair.personallySign(message)
 
-        val actualKey = personallySignedMessageToKey(message, signature)
-
-        assertThat(actualKey).isEqualTo(keyPair.publicKey)
-    }
-
-    @Test
-    fun retrievesCorrectPublicKeyFromPersonalHexSignature() {
-        val keyPair = createEthereumKeyPair()
-        val message = UUID.randomUUID().toString().toByteArray()
-        val signature = keyPair.personallySign(message).toHex()
-
-        val actualKey = personallySignedMessageToKey(message, signature)
+        val actualKey = personalSignedMessageToPublicKey(message, signature)
 
         assertThat(actualKey).isEqualTo(keyPair.publicKey)
     }

--- a/model/src/main/kotlin/org/kethereum/model/SignatureData.kt
+++ b/model/src/main/kotlin/org/kethereum/model/SignatureData.kt
@@ -28,7 +28,7 @@ data class SignatureData(
             }
             val cleanedHex = HexString(hexSignature).clean0xPrefix().string
             if (cleanedHex.length <= 128) {
-                throw SignatureException("Signature hex too short, expected more then 128 digits")
+                throw SignatureException("Signature hex too short, expected more than 128 digits")
             }
             val r = HexString(cleanedHex.substring(0, 64)).hexToBigInteger()
             val s = HexString(cleanedHex.substring(64, 128)).hexToBigInteger()

--- a/model/src/main/kotlin/org/kethereum/model/SignatureData.kt
+++ b/model/src/main/kotlin/org/kethereum/model/SignatureData.kt
@@ -1,8 +1,23 @@
 package org.kethereum.model
 
+import org.kethereum.extensions.hexToBigInteger
+import org.komputing.khex.extensions.clean0xPrefix
+import org.komputing.khex.model.HexString
 import java.math.BigInteger
 import java.math.BigInteger.ZERO
 
-data class SignatureData(var r: BigInteger = ZERO,
-                         var s: BigInteger = ZERO,
-                         var v: BigInteger = ZERO)
+data class SignatureData(
+    var r: BigInteger = ZERO,
+    var s: BigInteger = ZERO,
+    var v: BigInteger = ZERO,
+) {
+    companion object {
+        fun fromHex(hexSignature: String): SignatureData {
+            val cleanedHex = HexString(hexSignature).clean0xPrefix().string
+            val r = HexString(cleanedHex.substring(0, 64)).hexToBigInteger()
+            val s = HexString(cleanedHex.substring(64, 128)).hexToBigInteger()
+            val v = HexString(cleanedHex.substring(128)).hexToBigInteger()
+            return SignatureData(r, s, v)
+        }
+    }
+}

--- a/model/src/main/kotlin/org/kethereum/model/SignatureData.kt
+++ b/model/src/main/kotlin/org/kethereum/model/SignatureData.kt
@@ -2,9 +2,11 @@ package org.kethereum.model
 
 import org.kethereum.extensions.hexToBigInteger
 import org.komputing.khex.extensions.clean0xPrefix
+import org.komputing.khex.extensions.isValidHex
 import org.komputing.khex.model.HexString
 import java.math.BigInteger
 import java.math.BigInteger.ZERO
+import java.security.SignatureException
 
 data class SignatureData(
     var r: BigInteger = ZERO,
@@ -12,8 +14,22 @@ data class SignatureData(
     var v: BigInteger = ZERO,
 ) {
     companion object {
+        /**
+         * Build SignatureData object from Ethereum message signature in hex format.
+         *
+         * @param hexSignature Message signature as hex string.
+         * @return SignatureData
+         * @throws SignatureException If there was a signature format error.
+         */
+        @Throws(SignatureException::class)
         fun fromHex(hexSignature: String): SignatureData {
+            if (!HexString(hexSignature).isValidHex()) {
+                throw SignatureException("Invalid hex string: $hexSignature")
+            }
             val cleanedHex = HexString(hexSignature).clean0xPrefix().string
+            if (cleanedHex.length <= 128) {
+                throw SignatureException("Signature hex too short, expected more then 128 digits")
+            }
             val r = HexString(cleanedHex.substring(0, 64)).hexToBigInteger()
             val s = HexString(cleanedHex.substring(64, 128)).hexToBigInteger()
             val v = HexString(cleanedHex.substring(128)).hexToBigInteger()


### PR DESCRIPTION
**KEthereum** already has `SignatureData` to `PublicKey` conversion (org.kethereum.crypto.SignKt#signedMessageToKey), but I've stumbled on the need to convert EIP-191 personal signature to `PublicKey` (see this sample repo for use case https://github.com/vchernetskyi993/ethereum-server-auth).

From my perspective, these two new functions `HexString.toSignatureData` and `personallySignedMessageToKey` should be in the **KEthereum** code base, since they are quite re-usable across projects. Therefore, this PR.

@ligi please, review and tell me your thoughts (it's my first commit to your repo, so sorry in advance for any inaccuracies)