### PR TITLE
added stringCall to EthereumRPC

### DIFF
--- a/rpc/src/main/kotlin/org/kethereum/rpc/BaseEthereumRPC.kt
+++ b/rpc/src/main/kotlin/org/kethereum/rpc/BaseEthereumRPC.kt
@@ -34,7 +34,7 @@ open class BaseEthereumRPC(private val transport: RPCTransport) : EthereumRPC {
 
     private val feeHistoryAdapter: JsonAdapter<FeeHistoryResponse> = moshi.adapter(FeeHistoryResponse::class.java)
 
-    private fun stringCall(function: String, params: String = ""): StringResultResponse? {
+    override fun stringCall(function: String, params: String): StringResultResponse? {
         return transport.call(function, params)?.let { string -> stringResultAdapter.fromJsonNoThrow(string) }
     }
 

--- a/rpc/src/main/kotlin/org/kethereum/rpc/EthereumRPC.kt
+++ b/rpc/src/main/kotlin/org/kethereum/rpc/EthereumRPC.kt
@@ -3,6 +3,7 @@ package org.kethereum.rpc
 import org.kethereum.model.*
 import org.kethereum.rpc.model.BlockInformation
 import org.kethereum.rpc.model.FeeHistory
+import org.kethereum.rpc.model.StringResultResponse
 import org.komputing.khex.model.HexString
 import java.math.BigInteger
 
@@ -12,6 +13,7 @@ interface EthereumRPC {
     fun getBlockByNumber(number: BigInteger): BlockInformation?
     fun getTransactionByHash(hash: String): SignedTransaction?
 
+    fun stringCall(function: String, params: String = ""): StringResultResponse?
     fun sendRawTransaction(data: String): String?
     fun blockNumber(): BigInteger?
     fun call(transaction: Transaction, block: String = "latest"): HexString?

--- a/rpc/src/main/kotlin/org/kethereum/rpc/model/BaseResponse.kt
+++ b/rpc/src/main/kotlin/org/kethereum/rpc/model/BaseResponse.kt
@@ -3,7 +3,7 @@ package org.kethereum.rpc.model
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
-internal open class BaseResponse(
+open class BaseResponse(
         var jsonrpc: String = "",
         var id: String = "",
         var error: Error? = null

--- a/rpc/src/main/kotlin/org/kethereum/rpc/model/Error.kt
+++ b/rpc/src/main/kotlin/org/kethereum/rpc/model/Error.kt
@@ -3,7 +3,7 @@ package org.kethereum.rpc.model
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
-internal data class Error(
+data class Error(
         val message: String,
         val code: Int
 )

--- a/rpc/src/main/kotlin/org/kethereum/rpc/model/StringResultResponse.kt
+++ b/rpc/src/main/kotlin/org/kethereum/rpc/model/StringResultResponse.kt
@@ -3,4 +3,4 @@ package org.kethereum.rpc.model
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
-internal data class StringResultResponse(val result: String?) : BaseResponse()
+data class StringResultResponse(val result: String?) : BaseResponse()


### PR DESCRIPTION
An `EthereumRPC` should be able to interact directly with RPC providers, such as external wallets that implement custom RPC endpoints. This PR makes `stringCall` public, providing this flexibility to users. 

This is a common feature in web3 libraries that is missing from KEthereum. I know it is present in: 
- web3j (Java)
- ethers (JavaScript)
- ethers (Rust)
- web3 (Python)
- metamask-ios-sdk (Swift)

This feature is necessary for my use case. I work at [Polywrap](https://polywrap.io) and am writing a Kotlin Polywrap client with an Ethereum Wallet plugin.